### PR TITLE
Fix contactee show

### DIFF
--- a/app/controllers/contact_attempts_controller.rb
+++ b/app/controllers/contact_attempts_controller.rb
@@ -37,7 +37,7 @@ class ContactAttemptsController < ApplicationController
 
   def contact_attempt_params
     params.require(:contact_attempt).permit(:contact_type, :direction_type, :result_type,
-                                            :notes, :contactee_id,
+                                            :notes, :contactee_id, :contactor_id,
                                             :attempted_at_time_str, :attempted_at_date_str)
   end
 end

--- a/app/controllers/contact_banks_controller.rb
+++ b/app/controllers/contact_banks_controller.rb
@@ -49,9 +49,14 @@ class ContactBanksController < ApplicationController
       contactees = @contact_bank.contactees.contacted_by(@contact_bank.contactor_for_user(current_user))
     end
 
-    contactee = contactees.shuffle.first
+    if contactees.present?
+      contactee = contactees.shuffle.first
 
-    redirect_to contactee
+      redirect_to contactee
+    else
+      flash[:notice] = "There is no one else to contact."
+      redirect_to @contact_bank
+    end
   end
 
   private

--- a/app/controllers/contactees_controller.rb
+++ b/app/controllers/contactees_controller.rb
@@ -3,7 +3,9 @@ class ContacteesController < ApplicationController
   before_action :set_contactee, only: [:show, :edit, :update]
 
   def show
-    @contact_attempt = ContactAttempt.new(contactee: @contactee, attempted_at: Time.now,
+    @contact_attempt = ContactAttempt.new(contactee: @contactee,
+                                          contactor: @contactee.contact_bank.contactor_for_user(current_user),
+                                          attempted_at: Time.now,
                                           contact_type: ContactAttempt::CONTACT_TYPE_PHONE_CALL,
                                           direction_type: ContactAttempt::CONTACT_DIRECTION_OUT,
                                           result_type: ContactAttempt::CONTACT_RESULT_LEFT_MESSAGE)

--- a/app/models/contact_bank.rb
+++ b/app/models/contact_bank.rb
@@ -21,4 +21,8 @@ class ContactBank < ApplicationRecord
   def contactees_contacted
     contactees.contacted
   end
+
+  def contactor_for_user(user)
+    contactors.where(user_id: user.id).first
+  end
 end

--- a/app/views/contact_attempts/_form.html.haml
+++ b/app/views/contact_attempts/_form.html.haml
@@ -1,5 +1,6 @@
 = semantic_form_for [@contactee, @contact_attempt] do |f|
   = f.input :contactee_id, as: :hidden
+  = f.input :contactor_id, as: :hidden
   .row
     .col-md-4
       = f.input :attempted_at_date_str, label: "Attempted at date"

--- a/app/views/contact_banks/show.html.haml
+++ b/app/views/contact_banks/show.html.haml
@@ -26,7 +26,7 @@
           = render partial: 'contactees/summary', locals: { contactee: contactee }
     - else
       %ul
-        - @contact_bank.contactees.contacted_by(current_user).each do |contactee|
+        - @contact_bank.contactees.contacted_by(@contact_bank.contactor_for_user(current_user)).each do |contactee|
           = render partial: 'contactees/summary', locals: { contactee: contactee }
     %hr
     %h3 Stats


### PR DESCRIPTION
Fixed several problems with the showing of contactees on contact bank show page.

* It didn't work if all contactees had been contacted once because contactor_for_user wasn't even defined.
* It wasn't storing who the contactor was on an attempt
* It also wasn't filtering by contactor, but by user.
